### PR TITLE
Allow passing in the port as an env variable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import * as opn from 'opn';
 
 const cors = require('cors');
 
-const DEFAULT_PORT = 9002;
+const DEFAULT_PORT = process.env.PORT || 9002;
 const argv = require('yargs')
   .usage('Usage: $0 [file]')
   .alias('p', 'port')


### PR DESCRIPTION
This adds compatibility with services such as Zeit's `now`

Feel free to take it or leave it. I happen to be making this change locally to allow compatibility and figured I'd share