### PR TITLE
signal handling in docker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,15 @@ function runServer(schemaIDL: Source, extensionIDL: Source, optionsCB) {
 
   app.use('/editor', express.static(path.join(__dirname, 'editor')));
 
-  app.listen(argv.port);
+  const server = app.listen(argv.port);
+
+  const shutdown = () => {
+    server.close();
+    process.exit(0);
+  });
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 
   log(`\n${chalk.green('✔')} Your GraphQL Fake API is ready to use 🚀
   Here are your links:


### PR DESCRIPTION
Handle signals correctly when running in docker, making stop / restart much quicker.

Before change

ᐅ time docker-compose stop graphql-repl
Stopping graphql-repl_1 ... done
docker-compose stop graphql-repl  1.16s user 0.26s system 11% cpu 12.056 total

After change

ᐅ time docker-compose stop graphql-repl
docker-compose stop graphql-repl  0.60s user 0.11s system 92% cpu 0.757 total