### PR TITLE
relative paths for fetcher calls

### DIFF
--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -57,8 +57,7 @@ class FakeEditor extends React.Component<any, FakeEditorState> {
   }
 
   fetcher(url, options = {}) {
-    const {protocol, host} = window.location;
-    const baseUrl = `${protocol}//${host}`;
+    const baseUrl = '..'
     return fetch(baseUrl + url, {
       credentials: 'include',
       ...options,


### PR DESCRIPTION
prefix the fetcher calls with '..' allowing `graphql-faker` to work with a reverse proxy like traefik or nginx.

Removed protocol and port too.

This change will not affect the fetch call when running locally.