### PR TITLE
Bump `moment`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "faker": "^4.1.0",
     "graphql": "github:apis-guru/graphql-js#directives-fork-dist",
     "lodash": "^4.17.4",
-    "moment": "^2.19.0",
+    "moment": "^2.19.3",
     "node-fetch": "^1.7.3",
     "opn": "^5.1.0",
     "yargs": "^10.0.3"


### PR DESCRIPTION
Versions below `2.19.3` are flagged as insecure.