### PR TITLE
Clarify the need for -- after forward-headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ Extend real data from GitHub API with faked data based on extension IDL (you can
  * `--co`, `--cors-origin` CORS: Specify the origin for the Access-Control-Allow-Origin header
  * `-h`, `--help`          Show help
  
-When specifying the `[IDL file]` after the `--forward-headers` option you need to prefix it with `--` to clarify it's not another header. For example:
+When specifying the `[SDL file]` after the `--forward-headers` option you need to prefix it with `--` to clarify it's not another header. For example:
 ```
-graphql-faker --forward-headers Authorition -- ./temp.faker.graphql
+graphql-faker --extend http://example.com/graphql --forward-headers Authorition -- ./temp.faker.graphql
 ```
 When you finish with an other option there is no need for the `--`:
 ```
-graphql-faker --forward-headers Authorition --extend http://localhost:8091/graphql ./temp.faker.graphql
+graphql-faker --forward-headers Authorition --extend http://example.com/graphql ./temp.faker.graphql
 ```
 
 ### Usage with Docker

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ When specifying the `[IDL file]` after the `--forward-headers` option you need t
 ```
 graphql-faker --forward-headers Authorition -- ./temp.faker.graphql
 ```
+When you finish with an other option there is no need for the `--`:
+```
+graphql-faker --forward-headers Authorition --extend http://localhost:8091/graphql ./temp.faker.graphql
+```
 
 ### Usage with Docker
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ Extend real data from GitHub API with faked data based on extension IDL (you can
  * `--forward-headers`     Specify which headers should be forwarded to the proxied server
  * `--co`, `--cors-origin` CORS: Specify the origin for the Access-Control-Allow-Origin header
  * `-h`, `--help`          Show help
+ 
+When specifying the `[IDL file]` after the `--forward-headers` option you need to prefix it with `--` to clarify it's not another header. For example:
+```
+graphql-faker --forward-headers Authorition -- ./temp.faker.graphql
+```
 
 ### Usage with Docker
 


### PR DESCRIPTION
I tried to clarify the need for `--` after forward-headers (a Yargs array option). I though including the [relevant Yargs docs](https://github.com/yargs/yargs/blob/master/docs/api.md#array) would be a bit to technical?

Related issue: https://github.com/APIs-guru/graphql-faker/issues/49