### PR TITLE
Upgrade Graphql-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "@types/express": "4.16.0",
     "@types/express-graphql": "0.6.1",
     "@types/faker": "4.1.3",
-    "@types/graphql": "0.11.4",
+    "@types/graphql": "14.0.0",
     "@types/lodash": "4.14.116",
     "@types/yargs": "11.1.1",
-    "nodemon": "1.18.3",
+    "nodemon": "1.18.4",
     "ts-node": "7.0.1",
-    "typescript": "3.0.1"
+    "typescript": "3.0.3"
   },
   "dependencies": {
     "body-parser": "1.18.3",
@@ -45,11 +45,12 @@
     "express": "4.16.3",
     "express-graphql": "github:apis-guru/express-graphql#rootValue_dist",
     "faker": "4.1.0",
-    "graphql": "github:apis-guru/graphql-js#directives-fork-dist",
-    "lodash": "4.17.10",
+    "graphql": "*",
+    "lodash": "4.17.11",
     "moment": "2.22.2",
     "node-fetch": "2.2.0",
     "opn": "5.3.0",
-    "yargs": "12.0.1"
+    "updates": "^4.3.0",
+    "yargs": "12.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-faker",
-  "version": "1.7.6",
+  "version": "1.7.6-damian0",
   "description": "Mock or extend your GraphQL API with faked data. No coding required",
   "main": "dist/index.js",
   "bin": "dist/index.js",
@@ -11,7 +11,7 @@
     "build:editor": "cd src/editor && yarn && npm run build && cd -",
     "build:typescript": "tsc",
     "copy:graphql": "cp src/*.graphql dist/",
-    "copy:editor": "mkdir -p dist/editor && cp src/editor/*.{html,js,css,svg} dist/editor",
+    "copy:editor": "mkdir -p dist/editor && bash -c \" cp src/editor/*.{html,js,css,svg} dist/editor\"",
     "build:all": "npm run build:editor && npm run build:typescript && npm run copy:graphql && npm run copy:editor"
   },
   "repository": {

--- a/src/editor/GraphQLEditor/GraphQLEditor.tsx
+++ b/src/editor/GraphQLEditor/GraphQLEditor.tsx
@@ -57,9 +57,11 @@ export default class GraphQLEditor extends React.Component<GraphQLEditorProps> {
       foldGutter: {
         minFoldSize: 4,
       },
+      /*
       lint: {
         schema,
       },
+      */
       hintOptions: {
         schema,
         closeOnUnfocus: false,
@@ -122,7 +124,7 @@ export default class GraphQLEditor extends React.Component<GraphQLEditorProps> {
     const { value, schema } = this.props;
 
     if (schema != prevProps.schema) {
-      this.editor.options.lint.schema = schema;
+      //this.editor.options.lint.schema = schema;
       this.editor.options.hintOptions.schema = schema;
       this.editor.options.info.schema = schema;
       this.editor.options.jump.schema = schema;

--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -94,7 +94,8 @@ class FakeEditor extends React.Component<any, FakeEditorState> {
 
   buildSchema(value) {
     if (this.state.proxiedSchemaIDL) {
-      let schema = buildSchema(this.state.proxiedSchemaIDL + '\n' + fakeIDL);
+      //In this case we dont need fakeIDL
+      let schema = buildSchema(this.state.proxiedSchemaIDL);
       return extendSchema(schema, parse(value));
     } else {
       return buildSchema(value + '\n' + fakeIDL);

--- a/src/editor/package.json
+++ b/src/editor/package.json
@@ -6,10 +6,10 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "codemirror": "5.23.0",
-    "codemirror-graphql": "github:apis-guru/codemirror-graphql#directives-fork-dist",
+    "codemirror": "^5.40.0",
+    "codemirror-graphql": "^0.6.12",
     "graphiql": "^0.9.3",
-    "graphql": "^0.9.0",
+    "graphql": "^14.0.2",
     "isomorphic-fetch": "^2.2.1",
     "marked": "^0.3.6",
     "react": "^15.4.2",

--- a/src/editor/package.json
+++ b/src/editor/package.json
@@ -8,7 +8,7 @@
     "classnames": "^2.2.5",
     "codemirror": "^5.40.0",
     "codemirror-graphql": "^0.6.12",
-    "graphiql": "^0.9.3",
+    "graphiql": "*",
     "graphql": "^14.0.2",
     "isomorphic-fetch": "^2.2.1",
     "marked": "^0.3.6",

--- a/src/editor/yarn.lock
+++ b/src/editor/yarn.lock
@@ -1211,20 +1211,20 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-codemirror-graphql@^0.6.3:
+codemirror-graphql@^0.6.12, codemirror-graphql@^0.6.3:
   version "0.6.12"
   resolved "https://registry.yarnpkg.com/codemirror-graphql/-/codemirror-graphql-0.6.12.tgz#91a273fe5188857524a30221d06e645b4ca41f00"
   dependencies:
     graphql-language-service-interface "^1.0.16"
     graphql-language-service-parser "^0.1.14"
 
-"codemirror-graphql@github:apis-guru/codemirror-graphql#directives-fork-dist":
-  version "0.6.3"
-  resolved "https://codeload.github.com/apis-guru/codemirror-graphql/tar.gz/518625d1d5229cffe1fceba62258683a03d62854"
-
 codemirror@5.23.0:
   version "5.23.0"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.23.0.tgz#ac9b6b2e163a79e915b44cf0f43cd115cf6982dc"
+
+codemirror@^5.40.0:
+  version "5.40.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.40.0.tgz#2f5ed47366e514f41349ba0fe34daaa39be4e257"
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -2475,11 +2475,11 @@ graphql@^0.12.3:
   dependencies:
     iterall "1.1.3"
 
-graphql@^0.9.0:
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.9.6.tgz#514421e9d225c29dfc8fd305459abae58815ef2c"
+graphql@^14.0.2:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.0.2.tgz#7dded337a4c3fd2d075692323384034b357f5650"
   dependencies:
-    iterall "^1.0.0"
+    iterall "^1.2.2"
 
 handle-thing@^1.2.5:
   version "1.2.5"
@@ -3035,9 +3035,13 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-iterall@1.1.3, iterall@^1.0.0:
+iterall@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
+
+iterall@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
 
 js-base64@^2.1.9:
   version "2.4.0"

--- a/src/fake_schema.ts
+++ b/src/fake_schema.ts
@@ -146,7 +146,7 @@ export function fakeSchema(schema: GraphQLSchema) {
 
   function abstractTypeResolver(type:GraphQLAbstractType) {
     const possibleTypes = schema.getPossibleTypes(type);
-    return () => ({__typename: getRandomItem(possibleTypes)});
+    return () => ({__typename: getRandomItem(possibleTypes as Array<GraphQLObjectType>)});
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,14 +170,19 @@ function buildServerSchema(idl, concatFake=true) {
 
 function runServer(schemaIDL: Source, extensionIDL: Source, optionsCB) {
   const app = express();
-
+  //Check if extend another fake schema to avoid add the fakeIDL
+  var concatAST=true;
+  if (schemaIDL.body.includes("fake__Locale")){
+    concatAST=false;
+  }
   if (extensionIDL) {
-    const schema = buildServerSchema(schemaIDL, false);
+    const schema = buildServerSchema(schemaIDL, concatAST);
     extensionIDL.body = extensionIDL.body.replace('<RootTypeName>', schema.getQueryType().name);
   }
   app.options('/graphql', cors(corsOptions))
   app.use('/graphql', cors(corsOptions), graphqlHTTP(req => {
-    const schema = buildServerSchema(schemaIDL);
+    
+    const schema = buildServerSchema(schemaIDL, concatAST);
     const forwardHeaders = pick(req.headers, forwardHeaderNames);
     return {
       ...optionsCB(schema, extensionIDL, forwardHeaders),

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,8 +160,11 @@ if (argv.e) {
   });
 }
 
-function buildServerSchema(idl) {
-  var ast = concatAST([parse(idl), fakeDefinitionAST]);
+function buildServerSchema(idl, concatFake=true) {
+  var ast =parse(idl);
+  if (concatFake){
+    var ast = concatAST([parse(idl), fakeDefinitionAST]);
+  }
   return buildASTSchema(ast);
 }
 
@@ -169,7 +172,7 @@ function runServer(schemaIDL: Source, extensionIDL: Source, optionsCB) {
   const app = express();
 
   if (extensionIDL) {
-    const schema = buildServerSchema(schemaIDL);
+    const schema = buildServerSchema(schemaIDL, false);
     extensionIDL.body = extensionIDL.body.replace('<RootTypeName>', schema.getQueryType().name);
   }
   app.options('/graphql', cors(corsOptions))

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -37,11 +37,14 @@ export function proxyMiddleware(url, headers) {
   return getIntrospection().then(introspection => {
     const introspectionSchema = buildClientSchema(introspection.data);
     const introspectionIDL = printSchema(introspectionSchema);
-
     return [introspectionIDL, (serverSchema, extensionIDL, forwardHeaders) => {
       const extensionAST = parse(extensionIDL);
+    
       const extensionFields = getExtensionFields(extensionAST);
+   
       const schema = extendSchema(serverSchema, extensionAST);
+      
+      
       fakeSchema(schema);
 
       //TODO: proxy extensions
@@ -104,7 +107,7 @@ function buildRootValue(response) {
 
 function getExtensionFields(extensionAST) {
   const extensionFields = {};
-  (extensionAST.definitions || []).forEach(def => {
+  extensionAST.definitions.forEach(def => {
     var extensionsDefintions = [
       Kind.SCALAR_TYPE_EXTENSION,
       Kind.SCHEMA_EXTENSION,
@@ -115,11 +118,11 @@ function getExtensionFields(extensionAST) {
       Kind.OBJECT_TYPE_EXTENSION,
       Kind.UNION_TYPE_EXTENSION
     ]
-    if (!extensionsDefintions.includes(def.kind))//def.kind !== Kind.TYPE_EXTENSION_DEFINITION)
-      return;
-    const typeName = def.definition.name.value;
+    if (extensionsDefintions.includes(def.kind)){
+      const typeName = def.name.value;
     // FIXME: handle multiple extends of the same type
-    extensionFields[typeName] = def.definition.fields.map(field => field.name.value);
+      extensionFields[typeName] = def.fields.map(field => field.name.value);
+    }
   });
   return extensionFields;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -105,7 +105,17 @@ function buildRootValue(response) {
 function getExtensionFields(extensionAST) {
   const extensionFields = {};
   (extensionAST.definitions || []).forEach(def => {
-    if (def.kind !== Kind.TYPE_EXTENSION_DEFINITION)
+    var extensionsDefintions = [
+      Kind.SCALAR_TYPE_EXTENSION,
+      Kind.SCHEMA_EXTENSION,
+      Kind.OPERATION_TYPE_DEFINITION,
+      Kind.ENUM_TYPE_EXTENSION,
+      Kind.INPUT_OBJECT_TYPE_EXTENSION,
+      Kind.INTERFACE_TYPE_EXTENSION,
+      Kind.OBJECT_TYPE_EXTENSION,
+      Kind.UNION_TYPE_EXTENSION
+    ]
+    if (!extensionsDefintions.includes(def.kind))//def.kind !== Kind.TYPE_EXTENSION_DEFINITION)
       return;
     const typeName = def.definition.name.value;
     // FIXME: handle multiple extends of the same type


### PR DESCRIPTION
Hi @IvanGoncharov, I did a upgrade of graphql-js version and modify some code for work correclty.
With that, now the new description syntaxt are working but I don't know if all work propertly because for our propuse only need that   (#41 ).

Also i had to disable the lint into codemirror because with the update, if you define any type on the schema always show an error about the type definition, the error is becuase is not executable... Maybe you can fix that.

I do the pull-request only for if you would like start your migration to new version with this base.

Thanks for all