### PR TITLE
Change default CORS behavior to reflect caller origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Extend real data from GitHub API with faked data based on extension IDL (you can
  * `-o`, `--open`          Open page with IDL editor and GraphiQL in browser
  * `-H`, `--header`        Specify headers to the proxied server in cURL format, e.g.: `Authorization: bearer XXXXXXXXX`
  * `--forward-headers`     Specify which headers should be forwarded to the proxied server
- * `--co`, `--cors-origin` CORS: Specify the origin for the Access-Control-Allow-Origin header
+ * `--co`, `--cors-origin` CORS: Specify the origin for the Access-Control-Allow-Origin header; `reflect` to [reflect request 'Origin' header](https://github.com/expressjs/cors#configuration-options)
  * `-h`, `--help`          Show help
  
 When specifying the `[SDL file]` after the `--forward-headers` option you need to prefix it with `--` to clarify it's not another header. For example:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Extend real data from GitHub API with faked data based on extension IDL (you can
  * `-o`, `--open`          Open page with IDL editor and GraphiQL in browser
  * `-H`, `--header`        Specify headers to the proxied server in cURL format, e.g.: `Authorization: bearer XXXXXXXXX`
  * `--forward-headers`     Specify which headers should be forwarded to the proxied server
- * `--co`, `--cors-origin` CORS: Specify the origin for the Access-Control-Allow-Origin header; only provide this if you don't want the default of [reflecting request 'Origin' header](https://github.com/expressjs/cors#configuration-options)
+ * `--co`, `--cors-origin` CORS: Specify the custom origin for the Access-Control-Allow-Origin header, by default it is the same as `Origin` header from the request
  * `-h`, `--help`          Show help
  
 When specifying the `[SDL file]` after the `--forward-headers` option you need to prefix it with `--` to clarify it's not another header. For example:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Extend real data from GitHub API with faked data based on extension IDL (you can
  * `-o`, `--open`          Open page with IDL editor and GraphiQL in browser
  * `-H`, `--header`        Specify headers to the proxied server in cURL format, e.g.: `Authorization: bearer XXXXXXXXX`
  * `--forward-headers`     Specify which headers should be forwarded to the proxied server
- * `--co`, `--cors-origin` CORS: Specify the origin for the Access-Control-Allow-Origin header; `reflect` to [reflect request 'Origin' header](https://github.com/expressjs/cors#configuration-options)
+ * `--co`, `--cors-origin` CORS: Specify the origin for the Access-Control-Allow-Origin header; only provide this if you don't want the default of [reflecting request 'Origin' header](https://github.com/expressjs/cors#configuration-options)
  * `-h`, `--help`          Show help
  
 When specifying the `[SDL file]` after the `--forward-headers` option you need to prefix it with `--` to clarify it's not another header. For example:

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,8 +24,6 @@ import { fakeSchema } from './fake_schema';
 import { proxyMiddleware } from './proxy';
 import { existsSync } from './utils';
 
-const REFLECT_ORIGIN = 'reflect';
-
 const argv = yargs
   .command('$0 [file]', '', cmd => cmd.options({
     'port': {
@@ -112,10 +110,9 @@ if (!argv.file) {
 const fakeDefinitionAST = readAST(path.join(__dirname, 'fake_definition.graphql'));
 const corsOptions = {}
 
-if (argv.co) {
-  corsOptions['origin'] =  argv.co === REFLECT_ORIGIN ? true : argv.co
-  corsOptions['credentials'] =  true
-}
+// Currently no way to turn CORS off entirely, but that is probably fine
+corsOptions['credentials'] =  true
+corsOptions['origin'] = argv.co ? argv.co : true
 
 let userIDL;
 if (existsSync(fileName)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ import { fakeSchema } from './fake_schema';
 import { proxyMiddleware } from './proxy';
 import { existsSync } from './utils';
 
+const REFLECT_ORIGIN = 'reflect';
+
 const argv = yargs
   .command('$0 [file]', '', cmd => cmd.options({
     'port': {
@@ -111,7 +113,7 @@ const fakeDefinitionAST = readAST(path.join(__dirname, 'fake_definition.graphql'
 const corsOptions = {}
 
 if (argv.co) {
-  corsOptions['origin'] =  argv.co
+  corsOptions['origin'] =  argv.co === REFLECT_ORIGIN ? true : argv.co
   corsOptions['credentials'] =  true
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ const argv = yargs
     },
     'cors-origin': {
       alias: 'co',
-      describe: 'CORS: Define Access-Control-Allow-Origin header',
+      describe: 'CORS: Specify the custom origin for the Access-Control-Allow-Origin header, by default it is the same as `Origin` header from the request',
       type: 'string',
       requiresArg: true,
     },
@@ -110,7 +110,6 @@ if (!argv.file) {
 const fakeDefinitionAST = readAST(path.join(__dirname, 'fake_definition.graphql'));
 const corsOptions = {}
 
-// Currently no way to turn CORS off entirely, but that is probably fine
 corsOptions['credentials'] =  true
 corsOptions['origin'] = argv.co ? argv.co : true
 


### PR DESCRIPTION
Fixes #59 

By default, the `Origin` header from the request will now be reflected back as `Access-Control-Allow-Origin`.

`npx graphql-faker`

```
curl -XOPTIONS -H 'Origin: http://localhost:1234' http://localhost:9002/graphql -v -v -v

*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 9002 (#0)
> OPTIONS /graphql HTTP/1.1
> Host: localhost:9002
> User-Agent: curl/7.58.0
> Accept: */*
> Origin: http://localhost:1234
>
< HTTP/1.1 204 No Content
< X-Powered-By: Express
< Access-Control-Allow-Origin: http://localhost:1234
< Vary: Origin, Access-Control-Request-Headers
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Methods: GET,HEAD,PUT,PATCH,POST,DELETE
< Content-Length: 0
< Date: Wed, 17 Oct 2018 21:20:23 GMT
< Connection: keep-alive
<
* Connection #0 to host localhost left intact
```

This can be restricted to particular origins using the `--cors-origin` header as before.