### PR TITLE
Add support for @sample directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ In the GIF bellow we add fields to types inside real GitHub API and you can make
 
 ## How does it work?
 
-We use `@fake` directive to let you specify how to fake data. And if 60+ fakers is not enough for you, just use `@examples` directive to provide examples. Just add a directive to any field or custom scalar definition:
+We use `@fake` directive to let you specify how to fake data. And if 60+ fakers is not enough for you, just use `@examples` directive to provide examples. Use `@sample` directive to specify number of returned array items. Add a directive to any field or custom scalar definition:
 
     type Person {
       name: String @fake(type: firstName)
       gender: String @examples(values: ["male", "female"])
+      pets: [Pet] @sample(min: 1, max: 10)
     }
 
 No need to remember or read any docs. Autocompletion is included!

--- a/src/fake_definition.graphql
+++ b/src/fake_definition.graphql
@@ -197,7 +197,7 @@ input fake__options {
 }
 
 directive @fake(type:fake__Types!, options: fake__options = {}, locale:fake__Locale) on FIELD_DEFINITION | SCALAR
-
+directive @sample(min: Int!, max: Int!) on FIELD_DEFINITION | SCALAR
 
 scalar examples__JSON
 directive @examples(values: [examples__JSON]!) on FIELD_DEFINITION | SCALAR

--- a/src/fake_schema.ts
+++ b/src/fake_schema.ts
@@ -35,9 +35,14 @@ type FakeArgs = {
 type ExamplesArgs = {
   values:[any]
 };
+type SampleArgs = {
+  min: number;
+  max: number;
+};
 type DirectiveArgs = {
   fake?: FakeArgs
-  examples?: ExamplesArgs
+  examples?: ExamplesArgs,
+  sample ?: SampleArgs
 };
 
 const stdTypeNames = Object.keys(typeFakers);
@@ -135,7 +140,7 @@ export function fakeSchema(schema: GraphQLSchema) {
     if (type instanceof GraphQLNonNull)
       return getResolver(type.ofType, field);
     if (type instanceof GraphQLList)
-      return arrayResolver(getResolver(type.ofType, field));
+      return arrayResolver(getResolver(type.ofType, field), getFakeDirectives(field));
 
     if (isAbstractType(type))
       return abstractTypeResolver(type);
@@ -177,9 +182,19 @@ function fieldResolver(type:GraphQLOutputType, field) {
   }
 }
 
-function arrayResolver(itemResolver) {
+function arrayResolver(itemResolver, { sample }: DirectiveArgs) {
+  const options = {
+    min: 2,
+    max: 4,
+    ...sample,
+  } as SampleArgs;
+
+  if (options.min > options.max) {
+    options.max = ++options.min;
+  };
+
   return (...args) => {
-    let length = getRandomInt(2, 4);
+    let length = getRandomInt(options.min, options.max);
     const result = [];
 
     while (length-- !== 0)
@@ -198,6 +213,8 @@ function getFakeDirectives(object: any) {
     result.fake = directives.getDirectiveArgs('fake') as FakeArgs;
   if (directives.isApplied('examples'))
     result.examples = directives.getDirectiveArgs('examples') as ExamplesArgs;
+  if (directives.isApplied('sample'))
+    result.sample = directives.getDirectiveArgs('sample') as SampleArgs;
   return result;
 }
 


### PR DESCRIPTION
In order to allow number of items which were hardcoded in `arrayResolver` I added `@sample` directive. (Naming taken from `lodash`/`underscore`)

Fixes #12 