### PR TITLE
Proxy GraphQL errors when extending external API

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -52,7 +52,7 @@ export function proxyMiddleware(serverRequest, serverSchema, extensionSDL) {
 }
 
 function buildRootValue(response) {
-  const rootValue = response.data;
+  const rootValue = response.data || {};
   const globalErrors = [];
 
   for (const error of (response.errors || [])) {


### PR DESCRIPTION
This aims to resolve https://github.com/APIs-guru/graphql-faker/issues/70.

My problem was that the data on the response would be null if there's GraphQL errors. The `pathSet` on the rootValue would be applied on `null`. lodash's `set` allows this for some reason