### PR TITLE
Fix pass header argument

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,7 +87,7 @@ export function parseCLI(commandCB: (options: Options) => void) {
       corsOrigin: argv['cors-origin'],
       openEditor: argv.open,
       extendURL: argv.extend,
-      headers: argv.headers || {},
+      headers: argv.header || {},
       forwardHeaders: argv.forwardHeaders || [],
     });
   }


### PR DESCRIPTION
This is a quick fix, but I guess the more right name for cli arguments it `headers`