### PR TITLE
Don't overwrite real fields when mutation argument is the same

### DIFF
--- a/src/fake_schema.ts
+++ b/src/fake_schema.ts
@@ -82,12 +82,12 @@ export const fakeFieldResolver: GraphQLFieldResolver<unknown, unknown> = async (
   if (isMutation && isCompositeReturn && isPlainObject(resolved)) {
     const inputArg = args['input'];
     return {
-      ...resolved,
       ...(
         Object.keys(args).length === 1 && isPlainObject(inputArg)
           ? inputArg
           : args
       ),
+      ...resolved
     };
   }
 


### PR DESCRIPTION
Fixes #97

in #80 where passed in values from a mutation were returned in the payload if the field name is the same, this was overwritting real values whereas it should only be applied to fake values. Changing the order in which the fake and real objects are spread to construct the responses fixes this. 
 
