### PR TITLE
Make package.json scripts windows friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "nodemon -e ts --exec ts-node src/index.ts",
+    "start": "nodemon src/index.ts",
     "debug": "ts-node --inspect --compilerOptions '{\"inlineSources\":true}' src/index.ts",
     "build:editor": "cd src/editor && yarn && npm run build && cd ../..",
     "build:typescript": "tsc",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "build:editor": "cd src/editor && yarn && npm run build && cd ../..",
     "build:typescript": "tsc",
     "copy:graphql": "cp src/*.graphql dist/",
-    "copy:editor": "(mkdir -p dist/editor || mkdir dist\\editor || true) && cp src/editor/*.{html,js,css,svg} dist/editor",
-    "build:all": "npm run build:editor && npm run build:typescript && npm run copy:graphql && npm run copy:editor"
+    "copy:editor": "mkdir \"dist/editor\" && cp src/editor/*.{html,js,css,svg} dist/editor",
+    "build:all": "mkdir dist && npm run build:editor && npm run build:typescript && npm run copy:graphql && npm run copy:editor"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "nodemon -e ts --exec ts-node src/index.ts",
     "debug": "ts-node --inspect --compilerOptions '{\"inlineSources\":true}' src/index.ts",
-    "build:editor": "cd src/editor && yarn && npm run build && cd .. && cd ..",
+    "build:editor": "cd src/editor && yarn && npm run build && cd ../..",
     "build:typescript": "tsc",
     "copy:graphql": "cp src/*.graphql dist/",
     "copy:editor": "(mkdir -p dist/editor || mkdir dist\\editor || true) && cp src/editor/*.{html,js,css,svg} dist/editor",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "nodemon -e ts --exec 'ts-node src/index.ts'",
+    "start": "nodemon -e ts --exec ts-node src/index.ts",
     "debug": "ts-node --inspect --compilerOptions '{\"inlineSources\":true}' src/index.ts",
-    "build:editor": "cd src/editor && yarn && npm run build && cd -",
+    "build:editor": "cd src/editor && yarn && npm run build && cd .. && cd ..",
     "build:typescript": "tsc",
     "copy:graphql": "cp src/*.graphql dist/",
-    "copy:editor": "mkdir -p dist/editor && cp src/editor/*.{html,js,css,svg} dist/editor",
+    "copy:editor": "(mkdir -p dist/editor || mkdir dist\\editor || true) && cp src/editor/*.{html,js,css,svg} dist/editor",
     "build:all": "npm run build:editor && npm run build:typescript && npm run copy:graphql && npm run copy:editor"
   },
   "repository": {


### PR DESCRIPTION
without that I even wont be able to run faker on windows

things changed:

- `--exec ts-node src/index.ts` which is more correct way to use ts-node, without that cmd complains that ts-node is unknown
- `cd .. && cd ..` unfortunatelly there is no `cd -` in windows
- `(mkdir -p dist/editor || mkdir dist\\editor || true)` little bit ugly but in windows mkdir is working in `-p` mode out of the box, btw should it care at all, e.g. copying graphql does not