### PR TITLE
Adding a local docker file so you can run non-released code

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,13 @@
+FROM node:8.8.1-alpine
+
+RUN apk --no-cache update && \
+    apk --no-cache add gettext ca-certificates && \
+    rm -rf /var/cache/apk/*
+
+WORKDIR /workdir
+COPY ./ ./
+
+RUN yarn
+ENTRYPOINT ["npm", "start"]
+
+EXPOSE 9002


### PR DESCRIPTION
File to allow people to build a docker continer that isn't tied to the main line release - so we can run custom code while we wait for PRs (or to allow a bit of forking if the PR gets rejected).

```
docker build -f Dockerfile.local . -t graphql-faker
```

Then in your docker-compose, you can just swap the image for the real one: 

```
  service-mock:
    image: graphql-faker:latest
    command: myschema.graphql
    ports:
      - "9002:9002"
    volumes:
      - ../myschema.graphql:/workdir/myschema.graphql
```