### PR TITLE
temporary workaround for copy issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,14 +65,13 @@
       "dev": true
     },
     "@types/express": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
-      "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
-        "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:editor": "webpack -p --config webpack.config.js",
     "build:typescript": "tsc",
     "copy:graphql": "cp src/*.graphql dist/",
-    "copy:editor": "mkdir \"dist/editor\" && cp src/editor/*.{html,js,css,svg} dist/editor",
+    "copy:editor": "mkdir \"dist/editor\" && cp src/editor/*.html dist/editor && cp src/editor/*.js dist/editor && cp src/editor/*.css dist/editor && cp src/editor/*.svg dist/editor",
     "build:all": "rm -rf dist && mkdir dist && npm run build:editor && npm run build:typescript && npm run copy:graphql && npm run copy:editor",
     "prettier": "prettier --ignore-path .gitignore --write --list-different .",
     "prettier:check": "prettier --ignore-path .gitignore --check ."
@@ -34,7 +34,7 @@
     "@types/body-parser": "1.19.0",
     "@types/classnames": "2.2.10",
     "@types/cors": "2.8.6",
-    "@types/express": "4.17.6",
+    "@types/express": "^4.17.1",
     "@types/faker": "4.1.12",
     "@types/react": "16.9.35",
     "@types/react-dom": "16.9.8",


### PR DESCRIPTION
fix for #113 it is kind of ugly but working in either case as you have mentioned editor itself probably should be part of src and have no separate package.json which will make things much easier in future

ps: also downgraded @types/express to match installed express version without it build is broken

in my fork github action is green hope after creating PR to see it green also