### PR TITLE
Update node image version. Node 8.x is utterly old.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.8.1-alpine
+FROM node:14.3.0-alpine
 
 ENTRYPOINT ["node", "/usr/local/bin/graphql-faker"]
 WORKDIR /workdir


### PR DESCRIPTION
It seems like root-ca in node-8.8.1 has expired. Related issue: https://github.com/APIs-guru/graphql-faker/issues/117
Update Node image to 14.3.0