### PR TITLE
enable TypeScript declaration files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declaration": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "module": "commonjs",


### PR DESCRIPTION
Currently there are no reasons to not ship declaration files, since it allows to also reuse the internal utilities for programmatic usage

And enable possible incoming programmatic usage 👀 