### PR TITLE
Add support for fields overriding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,19 @@ src/editor/main.js
 src/editor/main.js.map
 src/editor/main.css
 src/editor/main.css.map
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In the GIF bellow we add fields to types inside real GitHub API and you can make
 
 ## How does it work?
 
-We use `@fake` directive to let you specify how to fake data. And if 60+ fakers is not enough for you, just use `@examples` directive to provide examples. Use `@override` directive to force existing field definition override.  Use `@listLength` directive to specify number of returned array items. Add a directive to any field or custom scalar definition:
+We use `@fake` directive to let you specify how to fake data. And if 60+ fakers is not enough for you, just use `@examples` directive to provide examples. Use `@override` directive to force existing field definition override. Use `@listLength` directive to specify number of returned array items. Add a directive to any field or custom scalar definition:
 
     type Person {
       name: String @fake(type: firstName)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Extend real data from GitHub API with faked data based on extension SDL (you can
 - `-H`, `--header` Specify headers to the proxied server in cURL format, e.g.: `Authorization: bearer XXXXXXXXX`
 - `--forward-headers` Specify which headers should be forwarded to the proxied server
 - `--co`, `--cors-origin` CORS: Specify the custom origin for the Access-Control-Allow-Origin header, by default it is the same as `Origin` header from the request
-- `--or`, `--override` Force overriding of existing field definitions (no need for `@override` directive)
+- `--or`, `--override` Force overriding of existing field definitions (no need for `@override` directive). Frontend needs to be reloaded if option value has changed.
 - `-h`, `--help` Show help
 
 When specifying the `[SDL file]` after the `--forward-headers` option you need to prefix it with `--` to clarify it's not another header. For example:

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ In the GIF bellow we add fields to types inside real GitHub API and you can make
 
 ## How does it work?
 
-We use `@fake` directive to let you specify how to fake data. And if 60+ fakers is not enough for you, just use `@examples` directive to provide examples. Use `@listLength` directive to specify number of returned array items. Add a directive to any field or custom scalar definition:
+We use `@fake` directive to let you specify how to fake data. And if 60+ fakers is not enough for you, just use `@examples` directive to provide examples. Use `@override` directive to force existing field definition override.  Use `@listLength` directive to specify number of returned array items. Add a directive to any field or custom scalar definition:
 
     type Person {
       name: String @fake(type: firstName)
       gender: String @examples(values: ["male", "female"])
+      age: Int @override @examples(values: [10, 20, 30])
       pets: [Pet] @listLength(min: 1, max: 10)
     }
 
@@ -73,6 +74,7 @@ Extend real data from GitHub API with faked data based on extension SDL (you can
 - `-H`, `--header` Specify headers to the proxied server in cURL format, e.g.: `Authorization: bearer XXXXXXXXX`
 - `--forward-headers` Specify which headers should be forwarded to the proxied server
 - `--co`, `--cors-origin` CORS: Specify the custom origin for the Access-Control-Allow-Origin header, by default it is the same as `Origin` header from the request
+- `--or`, `--override` Force overriding of existing field definitions (no need for `@override` directive)
 - `-h`, `--help` Show help
 
 When specifying the `[SDL file]` after the `--forward-headers` option you need to prefix it with `--` to clarify it's not another header. For example:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 import * as yargs from 'yargs';
 
-type Options = {
+export type Options = {
   fileName: string | undefined;
   port: number;
   corsOrigin: string | true;
@@ -8,6 +8,7 @@ type Options = {
   extendURL: string | undefined;
   headers: { [key: string]: string };
   forwardHeaders: [string];
+  overrideFields: boolean;
 };
 
 function builder(cmd) {
@@ -72,6 +73,12 @@ function builder(cmd) {
           return arr.map((str) => str.toLowerCase());
         },
       },
+      override: {
+        alias: 'or',
+        describe: 'Forces server to override existing field definitions',
+        type: 'boolean',
+        default: false,
+      },
     })
     .epilog(epilog)
     .strict();
@@ -90,6 +97,7 @@ export function parseCLI(commandCB: (options: Options) => void) {
       extendURL: argv.extend,
       headers: argv.header || {},
       forwardHeaders: argv.forwardHeaders || [],
+      overrideFields: argv.override,
     });
   }
 }

--- a/src/default-extend.graphql
+++ b/src/default-extend.graphql
@@ -4,6 +4,7 @@
 # Also you can use following two directives to enhance fake data:
 #   - @fake
 #   - @examples
+#   - @override
 #
 # Press save or Cmd+Enter to apply the changes and update server. Switch to GraphiQL
 # on the left panel to immediately test your changes.

--- a/src/default-schema.graphql
+++ b/src/default-schema.graphql
@@ -1,8 +1,9 @@
 # This is sample SDL schema for GraphQL Faker.
 #
-# There are two directives you can use to enhance fake data:
+# There are three directives you can use to enhance fake data:
 #   - @fake
 #   - @examples
+#   - @override
 # Each directive has autocompletion working so start by typing @
 #
 # Press save or Cmd+Enter to apply the changes and update server. Switch to GraphiQL

--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -17,6 +17,7 @@ import GraphQLEditor from './GraphQLEditor/GraphQLEditor';
 import { ConsoleIcon, EditIcon, GithubIcon, VoyagerIcon } from './icons';
 
 import { Voyager } from 'graphql-voyager';
+import { Options } from '../cli';
 
 type FakeEditorState = {
   value: string | null;
@@ -28,6 +29,7 @@ type FakeEditorState = {
   schema: GraphQLSchema | null;
   unsavedSchema: GraphQLSchema | null;
   remoteSDL: string | null;
+  serverOptions: Options | null;
 };
 
 class FakeEditor extends React.Component<any, FakeEditorState> {
@@ -44,6 +46,7 @@ class FakeEditor extends React.Component<any, FakeEditorState> {
       status: null,
       schema: null,
       remoteSDL: null,
+      serverOptions: null,
     };
   }
 
@@ -75,11 +78,12 @@ class FakeEditor extends React.Component<any, FakeEditorState> {
     }).then((response) => response.json());
   }
 
-  updateValue({ userSDL, remoteSDL }) {
+  updateValue({ userSDL, remoteSDL, serverOptions }) {
     this.setState({
       value: userSDL,
       cachedValue: userSDL,
       remoteSDL,
+      serverOptions,
     });
     this.updateSDL(userSDL, true);
   }
@@ -92,7 +96,12 @@ class FakeEditor extends React.Component<any, FakeEditorState> {
     });
   }
 
-  buildSchema(userSDL, options?) {
+  buildSchema(userSDL, localOptions?) {
+    const options = {
+      ...localOptions,
+      overrideFields: this.state.serverOptions?.overrideFields,
+    };
+
     if (this.state.remoteSDL) {
       return buildWithFakeDefinitions(
         new Source(this.state.remoteSDL),

--- a/src/fake_definition.ts
+++ b/src/fake_definition.ts
@@ -220,6 +220,8 @@ const fakeDefinitionAST = parse(/* GraphQL */ `
 
   scalar examples__JSON
   directive @examples(values: [examples__JSON]!) on FIELD_DEFINITION | SCALAR
+
+  directive @override on FIELD_DEFINITION
 `);
 
 function defToName(defNode) {
@@ -241,19 +243,62 @@ schemaWithOnlyFakedDefinitions['__validationErrors'] = [];
 export function buildWithFakeDefinitions(
   schemaSDL: Source,
   extensionSDL?: Source,
-  options?: { skipValidation: boolean },
+  options?: { skipValidation?: boolean; overrideFields?: boolean },
 ): GraphQLSchema {
   const skipValidation = options?.skipValidation ?? false;
-  const schemaAST = parseSDL(schemaSDL);
+  const overrideFields = options?.overrideFields ?? false;
 
-  // Remove Faker's own definitions that were added to have valid SDL for other
-  // tools, see: https://github.com/APIs-guru/graphql-faker/issues/75
+  const schemaAST = parseSDL(schemaSDL);
+  const extensionAST = extensionSDL && parseSDL(extensionSDL);
+
+  const extensionTypeDefinitions =
+    extensionAST !== undefined &&
+    extensionAST &&
+    extensionAST.definitions.filter(
+      (def) => def.kind === 'ObjectTypeExtension' && 'fields' in def,
+    );
+
   const filteredAST = {
     ...schemaAST,
-    definitions: schemaAST.definitions.filter((def) => {
-      const name = defToName(def);
-      return name === '' || !fakeDefinitionsSet.has(name);
-    }),
+    definitions: schemaAST.definitions
+      // Remove Faker's own definitions that were added to have valid SDL for other
+      // tools, see: https://github.com/APIs-guru/graphql-faker/issues/75
+      .filter((def) => {
+        const name = defToName(def);
+        return name === '' || !fakeDefinitionsSet.has(name);
+      })
+      // map DefinitionNodes to remove fields defined in the local schema from the remote schema
+      .map((schemaDefinition) => {
+        if (extensionTypeDefinitions) {
+          // looking for corresponding type definition extension in local schema
+          const correspondingExtensionTypeDefinition = extensionTypeDefinitions.find(
+            (extensionDef) =>
+              extensionDef.kind.slice(-9) === 'Extension' &&
+              (extensionDef as any).name.value ===
+                (schemaDefinition as any).name.value,
+          );
+
+          // remove field existing in both schemas from remote schema to make override possible
+          if (correspondingExtensionTypeDefinition) {
+            (schemaDefinition as any).fields = (schemaDefinition as any).fields.filter(
+              (fieldDef) =>
+                (correspondingExtensionTypeDefinition as any).fields.findIndex(
+                  (extensionFieldDef) =>
+                    overrideFields
+                      // match of field name is enough
+                      ? extensionFieldDef.name.value === fieldDef.name.value
+                      // check for both match of field name and `@override` directive usage
+                      : extensionFieldDef.name.value === fieldDef.name.value &&
+                        extensionFieldDef.directives?.findIndex(
+                          (x) => x.name.value === 'override',
+                        ) !== -1,
+                ) === -1,
+            );
+          }
+        }
+
+        return schemaDefinition;
+      }),
   };
 
   let schema = extendSchemaWithAST(schemaWithOnlyFakedDefinitions, filteredAST);
@@ -265,7 +310,7 @@ export function buildWithFakeDefinitions(
   });
 
   if (extensionSDL != null) {
-    schema = extendSchemaWithAST(schema, parseSDL(extensionSDL));
+    schema = extendSchemaWithAST(schema, extensionAST);
 
     for (const type of Object.values(schema.getTypeMap())) {
       if (isObjectType(type) || isInterfaceType(type)) {
@@ -292,9 +337,9 @@ export function buildWithFakeDefinitions(
 
   function extendSchemaWithAST(
     schema: GraphQLSchema,
-    extensionAST: DocumentNode,
+    extensionAST?: DocumentNode,
   ): GraphQLSchema {
-    if (!skipValidation) {
+    if (extensionAST && !skipValidation) {
       const errors = [
         ...validateSDL(extensionAST, schema),
         ...validate(schemaWithOnlyFakedDefinitions, extensionAST, [
@@ -306,10 +351,12 @@ export function buildWithFakeDefinitions(
       }
     }
 
-    return extendSchema(schema, extensionAST, {
-      assumeValid: true,
-      commentDescriptions: true,
-    });
+    return extensionAST
+      ? extendSchema(schema, extensionAST, {
+          assumeValid: true,
+          commentDescriptions: true,
+        })
+      : schema;
   }
 }
 

--- a/src/fake_definition.ts
+++ b/src/fake_definition.ts
@@ -285,10 +285,10 @@ export function buildWithFakeDefinitions(
                 (correspondingExtensionTypeDefinition as any).fields.findIndex(
                   (extensionFieldDef) =>
                     overrideFields
-                      // match of field name is enough
-                      ? extensionFieldDef.name.value === fieldDef.name.value
-                      // check for both match of field name and `@override` directive usage
-                      : extensionFieldDef.name.value === fieldDef.name.value &&
+                      ? // match of field name is enough
+                        extensionFieldDef.name.value === fieldDef.name.value
+                      : // check for both match of field name and `@override` directive usage
+                        extensionFieldDef.name.value === fieldDef.name.value &&
                         extensionFieldDef.directives?.findIndex(
                           (x) => x.name.value === 'override',
                         ) !== -1,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import * as graphqlHTTP from 'express-graphql';
 import { Source, printSchema } from 'graphql';
 import { express as voyagerMiddleware } from 'graphql-voyager/middleware';
 
-import { parseCLI } from './cli';
+import { Options, parseCLI } from './cli';
 import { getProxyExecuteFn } from './proxy';
 import { existsSync, readSDL, getRemoteSchema } from './utils';
 import { fakeTypeResolver, fakeFieldResolver } from './fake_schema';
@@ -80,12 +80,12 @@ parseCLI((options) => {
 });
 
 function runServer(
-  options,
+  options: Options,
   userSDL: Source,
   remoteSDL?: Source,
   customExecuteFn?,
 ) {
-  const { port, openEditor } = options;
+  const { port, openEditor, overrideFields } = options;
   const corsOptions = {
     credentials: true,
     origin: options.corsOrigin,
@@ -95,7 +95,7 @@ function runServer(
   let schema;
   try {
     schema = remoteSDL
-      ? buildWithFakeDefinitions(remoteSDL, userSDL)
+      ? buildWithFakeDefinitions(remoteSDL, userSDL, { overrideFields })
       : buildWithFakeDefinitions(userSDL);
   } catch (error) {
     if (error instanceof ValidationErrors) {
@@ -121,6 +121,8 @@ function runServer(
     res.status(200).json({
       userSDL: userSDL.body,
       remoteSDL: remoteSDL && remoteSDL.body,
+      // return cli options so frontend can properly work with fields overriding
+      serverOptions: options,
     });
   });
 
@@ -131,7 +133,7 @@ function runServer(
       fs.writeFileSync(fileName, req.body);
       userSDL = new Source(req.body, fileName);
       schema = remoteSDL
-        ? buildWithFakeDefinitions(remoteSDL, userSDL)
+        ? buildWithFakeDefinitions(remoteSDL, userSDL, { overrideFields })
         : buildWithFakeDefinitions(userSDL);
 
       const date = new Date().toLocaleString();


### PR DESCRIPTION
This PR enables support for both `@override` directive and `--override` CLI option.
Inspired by https://github.com/APIs-guru/graphql-faker/issues/17 and https://github.com/APIs-guru/graphql-faker/pull/135