### PR TITLE
Skip no string forward headers

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -22,7 +22,11 @@ export function getProxyExecuteFn(url, headers, forwardHeaders) {
     const request = contextValue as IncomingMessage;
     const proxyHeaders = Object.create(null);
     for (const name of forwardHeaders) {
-      proxyHeaders[name] = request.headers[name];
+      const incomingHeader = request.headers[name];
+
+      if (typeof incomingHeader === 'string' && incomingHeader.length > 0) {
+        proxyHeaders[name] = request.headers[name];
+      }
     }
 
     const strippedAST = removeUnusedVariables(


### PR DESCRIPTION
I have caught an issue with `--forward-headers`. If the incoming headers object doesn't contain a header, that declared in `--forward-headers` then in proxy headers object will be with this header with `undefined` value.