### PR TITLE
Update express-graphql

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2281,24 +2281,24 @@
       }
     },
     "express-graphql": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.9.0.tgz",
-      "integrity": "sha512-wccd9Lb6oeJ8yHpUs/8LcnGjFUUQYmOG9A5BNLybRdCzGw0PeUrtBxsIR8bfiur6uSW4OvPkVDoYH06z6/N9+w==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.10.2.tgz",
+      "integrity": "sha512-OV8L1li3e2kFegslfyxY/Geh0JCRy/pmZUQmiRP+B3LUuRq4w8D+esjZodhW4vh8N0SeA5fFZ1UvbnVkt/fGOw==",
       "requires": {
         "accepts": "^1.3.7",
         "content-type": "^1.0.4",
-        "http-errors": "^1.7.3",
+        "http-errors": "1.8.0",
         "raw-body": "^2.4.1"
       },
       "dependencies": {
         "http-errors": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
-          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
+          "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.4",
-            "setprototypeof": "1.1.1",
+            "setprototypeof": "1.2.0",
             "statuses": ">= 1.5.0 < 2",
             "toidentifier": "1.0.0"
           }
@@ -2317,7 +2317,31 @@
             "http-errors": "1.7.3",
             "iconv-lite": "0.4.24",
             "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "http-errors": {
+              "version": "1.7.3",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+              "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+              "requires": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.4",
+                "setprototypeof": "1.1.1",
+                "statuses": ">= 1.5.0 < 2",
+                "toidentifier": "1.0.0"
+              }
+            },
+            "setprototypeof": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+              "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+            }
           }
+        },
+        "setprototypeof": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+          "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "chalk": "4.0.0",
     "cors": "2.8.5",
     "express": "4.17.1",
-    "express-graphql": "0.9.0",
+    "express-graphql": "0.10.2",
     "faker": "4.1.0",
     "graphql": "14.5.8",
     "graphql-voyager": "1.0.0-rc.31",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import * as chalk from 'chalk';
 import * as open from 'open';
 import * as cors from 'cors';
 import * as bodyParser from 'body-parser';
-import * as graphqlHTTP from 'express-graphql';
+import { graphqlHTTP } from 'express-graphql';
 import { Source, printSchema } from 'graphql';
 import { express as voyagerMiddleware } from 'graphql-voyager/middleware';
 


### PR DESCRIPTION
This fixes a peer dep warning for graphql 15

Here's the [changelog](https://github.com/graphql/express-graphql/releases) for express-graphql

Highlights of the breaking changes in 0.10.0

* https://github.com/graphql/express-graphql/pull/608 Do not pass parameters if we can't parse them.
* https://github.com/graphql/express-graphql/pull/622 Sync TS typings with Flow typings
* https://github.com/graphql/express-graphql/pull/624 Flow cleanup typings
* https://github.com/graphql/express-graphql/pull/626 Convert CommonJS module syntax to ES6
* https://github.com/graphql/express-graphql/pull/638 Drop support for TS < 3.4