### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/fake.ts
+++ b/src/fake.ts
@@ -178,7 +178,7 @@ const fakeFunctions = {
     func: (min, max, precision) =>
       faker.datatype.number({ min, max, precision }),
   },
-  uuid: () => faker.random.uuid(),
+  uuid: () => faker.datatype.uuid(),
   word: () => faker.random.word(),
   words: () => faker.random.words(),
   locale: () => faker.random.locale(),


### PR DESCRIPTION
Fixes: 

```
Deprecation Warning: faker.random.uuid is now located in faker.datatype.uuid
```