### PR TITLE
Add port option to docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ graphql-faker --forward-headers Authorization --extend http://example.com/graphq
 
 To specify a custom file, mount a volume where the file is located to `/workdir`:
 
-    docker run -v=${PWD}:/workdir apisguru/graphql-faker path/to/schema.sdl
+    docker run -p=9002:9002 -v=${PWD}:/workdir apisguru/graphql-faker path/to/schema.sdl
 
 Because the process is running inside of the container, `--open` does not work.
 


### PR DESCRIPTION
Add port option to docker example specifying custom file in README.md.

This command seems to be not working without port option.
I know this is an example for `-v` option but I think it's better to write command that works without change.
https://github.com/IvanGoncharov/graphql-faker/blob/2775f1580a6cbe9d2fdf4a823a1374cbbbe3514c/README.md?plain=1#L96