### PR TITLE
Feat: Run over https protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,31 @@ In the GIF below we add fields to types inside real GitHub API and you can make 
 
 ## How does it work?
 
-We use `@fake` directive to let you specify how to fake data. And if 60+ fakers is not enough for you, just use `@examples` directive to provide examples. Use `@listLength` directive to specify number of returned array items. Add a directive to any field or custom scalar definition:
+We use `@fake` directive to let you specify how to fake data. And if 60+ fakers is not enough for you, just use `@examples` directive to provide examples. if you want to fake an exact values, use the `@value` directive. Use `@listLength` directive to specify number of returned array items. Add a directive to any field or custom scalar definition:
 
     type Person {
       name: String @fake(type: firstName)
       gender: String @examples(values: ["male", "female"])
       pets: [Pet] @listLength(min: 1, max: 10)
+    }
+
+Examples how to use exact values by `@value` directive:
+
+    enum PersonalRoles {
+          STUDENT,
+          MANAGER,
+          ADMINISTRATOR
+    }
+
+    type PersonRights {
+      name: String
+    }
+
+    type Person {
+      rights: [PersonRights!] @value(values: [{name: "READ"}, {name: "WRITE"}])
+      roles: [PersonalRoles] @value(values: ["STUDENT"])
+      isActive: @value(value: true)
+      staticToken: @value(value: "TOKEN")
     }
 
 No need to remember or read any docs. Autocompletion is included!

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Extend real data from GitHub API with faked data based on extension SDL (you can
 - `-H`, `--header` Specify headers to the proxied server in cURL format, e.g.: `Authorization: bearer XXXXXXXXX`
 - `--forward-headers` Specify which headers should be forwarded to the proxied server
 - `--co`, `--cors-origin` CORS: Specify the custom origin for the Access-Control-Allow-Origin header, by default it is the same as `Origin` header from the request
+- `--s`, `--ssl` Run over https protocol. this expects certificates in `./ssl` folder
 - `-h`, `--help` Show help
 
 When specifying the `[SDL file]` after the `--forward-headers` option you need to prefix it with `--` to clarify it's not another header. For example:

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Examples how to use exact values by `@value` directive:
     type Person {
       rights: [PersonRights!] @value(values: [{name: "READ"}, {name: "WRITE"}])
       roles: [PersonalRoles] @value(values: ["STUDENT"])
-      isActive: @value(value: true)
-      staticToken: @value(value: "TOKEN")
+      isActive: Boolean @value(value: true)
+      staticToken: String @value(value: "TOKEN")
     }
 
 No need to remember or read any docs. Autocompletion is included!

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ interface Options {
   fileName: string;
   port: number;
   corsOrigin: string | true;
+  ssl: boolean
   openEditor: boolean;
   extendURL: string | undefined;
   headers: { [key: string]: string };
@@ -57,6 +58,7 @@ export function parseCLI(): Options {
   return {
     fileName,
     port: parsePortNumber(values.port),
+    ssl: values.ssl,
     corsOrigin: values['cors-origin'] ?? values.co ?? true,
     openEditor: values.open,
     extendURL: values.extend,
@@ -92,6 +94,8 @@ export function parseCLI(): Options {
       -h, --help           Show help                                       [boolean]
       --port, -p           HTTP Port                        [number] [default: 9002]
       --open, -o           Open page with SDL editor and GraphiQL in browser
+                                                                           [boolean]
+      --ssl, -s            Run over https protocol
                                                                            [boolean]
       --cors-origin, --co  CORS: Specify the custom origin for the
                            Access-Control-Allow-Origin header, by default it is the
@@ -156,6 +160,10 @@ export function parseCLI(): Options {
             multiple: true,
             default: [],
           },
+          ssl : {
+            short: 's',
+            type: 'boolean',
+          }
         },
       });
     } catch (error) {

--- a/src/default-extend.graphql
+++ b/src/default-extend.graphql
@@ -4,6 +4,7 @@
 # Also you can use following two directives to enhance fake data:
 #   - @fake
 #   - @examples
+#   - @value
 #
 # Press save or Cmd+Enter to apply the changes and update server. Switch to GraphiQL
 # on the left panel to immediately test your changes.

--- a/src/fake_definition.ts
+++ b/src/fake_definition.ts
@@ -184,6 +184,8 @@ const fakeDefinitionAST = parse(/* GraphQL */ `
 
   scalar examples__JSON
   directive @examples(values: [examples__JSON]!) on FIELD_DEFINITION | SCALAR
+  directive @value(value: examples__JSON) on FIELD_DEFINITION | SCALAR
+  directive @values(values: [examples__JSON]!) on FIELD_DEFINITION | SCALAR
 `);
 
 function defToName(defNode) {

--- a/src/fake_definition.ts
+++ b/src/fake_definition.ts
@@ -184,8 +184,8 @@ const fakeDefinitionAST = parse(/* GraphQL */ `
 
   scalar examples__JSON
   directive @examples(values: [examples__JSON]!) on FIELD_DEFINITION | SCALAR
-  directive @value(value: examples__JSON) on FIELD_DEFINITION | SCALAR
-  directive @values(values: [examples__JSON]!) on FIELD_DEFINITION | SCALAR
+  scalar valueProperty
+  directive @value(value: valueProperty, values: [valueProperty]) on FIELD_DEFINITION | SCALAR
 `);
 
 function defToName(defNode) {

--- a/src/fake_schema.ts
+++ b/src/fake_schema.ts
@@ -48,6 +48,8 @@ interface DirectiveArgs {
   fake?: FakeArgs;
   examples?: ExamplesArgs;
   listLength?: ListLengthArgs;
+  value?: ValueArgs;
+  values?: ValuesArgs;
 }
 
 export const fakeTypeResolver: GraphQLTypeResolver<unknown, unknown> = async (

--- a/src/fake_schema.ts
+++ b/src/fake_schema.ts
@@ -27,30 +27,24 @@ interface FakeArgs {
   options: { [key: string]: any };
   locale: string;
 }
+
 interface ExamplesArgs {
   values: [any];
-  options: { [key: string]: any };
-}
-
-interface ValueArgs {
-  value: [any];
 }
 
 interface ValuesArgs {
   values: [any];
 }
 
+interface ValueArgs {
+  value: any;
+}
+
 interface ListLengthArgs {
   min: number;
   max: number;
 }
-interface DirectiveArgs {
-  fake?: FakeArgs;
-  examples?: ExamplesArgs;
-  listLength?: ListLengthArgs;
-  value?: ValueArgs;
-  values?: ValuesArgs;
-}
+type DirectiveArgs = FakeArgs | ValueArgs | ValuesArgs | ExamplesArgs | ListLengthArgs;
 
 export const fakeTypeResolver: GraphQLTypeResolver<unknown, unknown> = async (
   value,
@@ -178,7 +172,6 @@ export const fakeFieldResolver: GraphQLFieldResolver<unknown, unknown> = async (
   }
 
   function getValuesCB(object) {
-    console.log(object);
     const valuesDirective = schema.getDirective('values');
     const args = getDirectiveArgs(valuesDirective, object) as ValuesArgs;
     return args && (() => args.values);

--- a/src/fake_schema.ts
+++ b/src/fake_schema.ts
@@ -32,19 +32,16 @@ interface ExamplesArgs {
   values: [any];
 }
 
-interface ValuesArgs {
-  values: [any];
-}
-
 interface ValueArgs {
-  value: any;
+  value?: any;
+  values?: [any];
 }
 
 interface ListLengthArgs {
   min: number;
   max: number;
 }
-type DirectiveArgs = FakeArgs | ValueArgs | ValuesArgs | ExamplesArgs | ListLengthArgs;
+type DirectiveArgs = FakeArgs | ValueArgs | ExamplesArgs | ListLengthArgs;
 
 export const fakeTypeResolver: GraphQLTypeResolver<unknown, unknown> = async (
   value,
@@ -105,9 +102,7 @@ export const fakeFieldResolver: GraphQLFieldResolver<unknown, unknown> = async (
   function fakeValueOfType(type) {
     const plainValueCB =
         getValueCB(fieldDef) ||
-        getValuesCB(fieldDef) ||
-        getValueCB(type) ||
-        getValuesCB(type);
+        getValueCB(type);
 
     if(plainValueCB) {
       return plainValueCB();
@@ -168,13 +163,14 @@ export const fakeFieldResolver: GraphQLFieldResolver<unknown, unknown> = async (
   function getValueCB(object) {
     const valueDirective = schema.getDirective('value');
     const args = getDirectiveArgs(valueDirective, object) as ValueArgs;
-    return args && (() => args.value);
-  }
 
-  function getValuesCB(object) {
-    const valuesDirective = schema.getDirective('values');
-    const args = getDirectiveArgs(valuesDirective, object) as ValuesArgs;
-    return args && (() => args.values);
+    if(args?.value) {
+      return () => args.value;
+    }
+
+    if(args?.values) {
+      return () => args.values;
+    }
   }
 };
 

--- a/src/fake_schema.ts
+++ b/src/fake_schema.ts
@@ -29,7 +29,17 @@ interface FakeArgs {
 }
 interface ExamplesArgs {
   values: [any];
+  options: { [key: string]: any };
 }
+
+interface ValueArgs {
+  value: [any];
+}
+
+interface ValuesArgs {
+  values: [any];
+}
+
 interface ListLengthArgs {
   min: number;
   max: number;
@@ -97,6 +107,16 @@ export const fakeFieldResolver: GraphQLFieldResolver<unknown, unknown> = async (
   return resolved;
 
   function fakeValueOfType(type) {
+    const plainValueCB =
+        getValueCB(fieldDef) ||
+        getValuesCB(fieldDef) ||
+        getValueCB(type) ||
+        getValuesCB(type);
+
+    if(plainValueCB) {
+      return plainValueCB();
+    }
+
     if (isNonNullType(type)) {
       return fakeValueOfType(type.ofType);
     }
@@ -147,6 +167,19 @@ export const fakeFieldResolver: GraphQLFieldResolver<unknown, unknown> = async (
     const listLength = schema.getDirective('listLength');
     const args = getDirectiveArgs(listLength, object) as ListLengthArgs;
     return args ? getRandomInt(args.min, args.max) : getRandomInt(2, 4);
+  }
+
+  function getValueCB(object) {
+    const valueDirective = schema.getDirective('value');
+    const args = getDirectiveArgs(valueDirective, object) as ValueArgs;
+    return args && (() => args.value);
+  }
+
+  function getValuesCB(object) {
+    console.log(object);
+    const valuesDirective = schema.getDirective('values');
+    const args = getDirectiveArgs(valuesDirective, object) as ValuesArgs;
+    return args && (() => args.values);
   }
 };
 


### PR DESCRIPTION
in many cases, if we use an application in combination with a docker application that runs on https, I need the API to run under ssl as well.

I created an optional `--ssl` parameter that creates a proxy application above the node. This switch also expects to have server.cert and server.key certificates in the ./ssl folder
