### PR TITLE
Feat: Introduce @value definition for exact values

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,31 @@ In the GIF below we add fields to types inside real GitHub API and you can make 
 
 ## How does it work?
 
-We use `@fake` directive to let you specify how to fake data. And if 60+ fakers is not enough for you, just use `@examples` directive to provide examples. Use `@listLength` directive to specify number of returned array items. Add a directive to any field or custom scalar definition:
+We use `@fake` directive to let you specify how to fake data. And if 60+ fakers is not enough for you, just use `@examples` directive to provide examples. if you want to fake an exact values, use the `@value` directive. Use `@listLength` directive to specify number of returned array items. Add a directive to any field or custom scalar definition:
 
     type Person {
       name: String @fake(type: firstName)
       gender: String @examples(values: ["male", "female"])
       pets: [Pet] @listLength(min: 1, max: 10)
+    }
+
+Examples how to use exact values by `@value` directive:
+
+    enum PersonalRoles {
+          STUDENT,
+          MANAGER,
+          ADMINISTRATOR
+    }
+
+    type PersonRights {
+      name: String
+    }
+
+    type Person {
+      rights: [PersonRights!] @value(values: [{name: "READ"}, {name: "WRITE"}])
+      roles: [PersonalRoles] @value(values: ["STUDENT"])
+      isActive: Boolean @value(value: true)
+      staticToken: String @value(value: "TOKEN")
     }
 
 No need to remember or read any docs. Autocompletion is included!

--- a/src/default-extend.graphql
+++ b/src/default-extend.graphql
@@ -4,6 +4,7 @@
 # Also you can use following two directives to enhance fake data:
 #   - @fake
 #   - @examples
+#   - @value
 #
 # Press save or Cmd+Enter to apply the changes and update server. Switch to GraphiQL
 # on the left panel to immediately test your changes.

--- a/src/fake_definition.ts
+++ b/src/fake_definition.ts
@@ -184,6 +184,8 @@ const fakeDefinitionAST = parse(/* GraphQL */ `
 
   scalar examples__JSON
   directive @examples(values: [examples__JSON]!) on FIELD_DEFINITION | SCALAR
+  scalar valueProperty
+  directive @value(value: valueProperty, values: [valueProperty]) on FIELD_DEFINITION | SCALAR
 `);
 
 function defToName(defNode) {

--- a/src/fake_schema.ts
+++ b/src/fake_schema.ts
@@ -100,11 +100,9 @@ export const fakeFieldResolver: GraphQLFieldResolver<unknown, unknown> = async (
   return resolved;
 
   function fakeValueOfType(type) {
-    const plainValueCB =
-        getValueCB(fieldDef) ||
-        getValueCB(type);
+    const plainValueCB = getValueCB(fieldDef) || getValueCB(type);
 
-    if(plainValueCB) {
+    if (plainValueCB) {
       return plainValueCB();
     }
 
@@ -164,12 +162,12 @@ export const fakeFieldResolver: GraphQLFieldResolver<unknown, unknown> = async (
     const valueDirective = schema.getDirective('value');
     const args = getDirectiveArgs(valueDirective, object) as ValueArgs;
 
-    if(args?.value) {
-      return () => args.value;
+    if (typeof args?.value !== 'undefined') {
+      return args && (() => args.value);
     }
 
-    if(args?.values) {
-      return () => args.values;
+    if (typeof args?.values !== 'undefined') {
+      return args && (() => args.values);
     }
   }
 };

--- a/src/fake_schema.ts
+++ b/src/fake_schema.ts
@@ -27,18 +27,21 @@ interface FakeArgs {
   options: { [key: string]: any };
   locale: string;
 }
+
 interface ExamplesArgs {
   values: [any];
 }
+
+interface ValueArgs {
+  value?: any;
+  values?: [any];
+}
+
 interface ListLengthArgs {
   min: number;
   max: number;
 }
-interface DirectiveArgs {
-  fake?: FakeArgs;
-  examples?: ExamplesArgs;
-  listLength?: ListLengthArgs;
-}
+type DirectiveArgs = FakeArgs | ValueArgs | ExamplesArgs | ListLengthArgs;
 
 export const fakeTypeResolver: GraphQLTypeResolver<unknown, unknown> = async (
   value,
@@ -97,6 +100,14 @@ export const fakeFieldResolver: GraphQLFieldResolver<unknown, unknown> = async (
   return resolved;
 
   function fakeValueOfType(type) {
+    const plainValueCB =
+        getValueCB(fieldDef) ||
+        getValueCB(type);
+
+    if(plainValueCB) {
+      return plainValueCB();
+    }
+
     if (isNonNullType(type)) {
       return fakeValueOfType(type.ofType);
     }
@@ -147,6 +158,19 @@ export const fakeFieldResolver: GraphQLFieldResolver<unknown, unknown> = async (
     const listLength = schema.getDirective('listLength');
     const args = getDirectiveArgs(listLength, object) as ListLengthArgs;
     return args ? getRandomInt(args.min, args.max) : getRandomInt(2, 4);
+  }
+
+  function getValueCB(object) {
+    const valueDirective = schema.getDirective('value');
+    const args = getDirectiveArgs(valueDirective, object) as ValueArgs;
+
+    if(args?.value) {
+      return () => args.value;
+    }
+
+    if(args?.values) {
+      return () => args.values;
+    }
   }
 };
 


### PR DESCRIPTION
I missed one essential thing in the whole implementation, and that is setting the exact values according to the input. In some cases, this makes it impossible to use graphql-faker as a mock only with @fake and @examples directives. So I finished the @value directive, which might help someone else.

how does it work?

for enum value:
```
enum UserRole {
  STUDENT,
  BUSINESS_STUDENT,
  MANAGER
  BUSINESS_MANAGER,
  ADMINISTRATOR,
  SUPER_ADMINISTRATOR
}

...

type User {
   ...
   roles: [UserRole] @value(values: ["STUDENT", "BUSINESS_STUDENT"])
}
```

for Boolean or string values

```
  token: String @value(value: "TOKEN")
  isActive: String @value(value: true)
```

for other types:
```
  type FeatureFlag {
     name: String
  }

  featureFlags: [FeatureFlag!] @value(values: [{name: "cookie_banner"}, {name: "espresso"}])
```