### PR TITLE
Feat: Run over ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Extend real data from GitHub API with faked data based on extension SDL (you can
 - `-H`, `--header` Specify headers to the proxied server in cURL format, e.g.: `Authorization: bearer XXXXXXXXX`
 - `--forward-headers` Specify which headers should be forwarded to the proxied server
 - `--co`, `--cors-origin` CORS: Specify the custom origin for the Access-Control-Allow-Origin header, by default it is the same as `Origin` header from the request
+- `--s`, `--ssl` Run over https protocol. this expects certificates in `./ssl` folder
 - `-h`, `--help` Show help
 
 When specifying the `[SDL file]` after the `--forward-headers` option you need to prefix it with `--` to clarify it's not another header. For example:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ interface Options {
   fileName: string;
   port: number;
   corsOrigin: string | true;
+  ssl: boolean
   openEditor: boolean;
   extendURL: string | undefined;
   headers: { [key: string]: string };
@@ -57,6 +58,7 @@ export function parseCLI(): Options {
   return {
     fileName,
     port: parsePortNumber(values.port),
+    ssl: values.ssl,
     corsOrigin: values['cors-origin'] ?? values.co ?? true,
     openEditor: values.open,
     extendURL: values.extend,
@@ -92,6 +94,8 @@ export function parseCLI(): Options {
       -h, --help           Show help                                       [boolean]
       --port, -p           HTTP Port                        [number] [default: 9002]
       --open, -o           Open page with SDL editor and GraphiQL in browser
+                                                                           [boolean]
+      --ssl, -s            Run over https protocol
                                                                            [boolean]
       --cors-origin, --co  CORS: Specify the custom origin for the
                            Access-Control-Allow-Origin header, by default it is the
@@ -156,6 +160,10 @@ export function parseCLI(): Options {
             multiple: true,
             default: [],
           },
+          ssl : {
+            short: 's',
+            type: 'boolean',
+          }
         },
       });
     } catch (error) {


### PR DESCRIPTION
in many cases, if we use an application in combination with a docker application that runs on https, I need the API to run under ssl as well.

I created an optional `--ssl` parameter that creates a proxy application above the node. This switch also expects to have server.cert and server.key certificates in the ./ssl folder