### PR TITLE
feat(core): Add dateInRange fake

### DIFF
--- a/src/default-schema.graphql
+++ b/src/default-schema.graphql
@@ -26,6 +26,15 @@ type Employee {
   address: String @fake(type: streetAddress, options: { useFullAddress: true })
   subordinates: [Employee!] @listLength(min: 0, max: 3)
   company: Company
+  workDates: [String!]
+    @fake(
+      type: dateInRange
+      options: {
+        dateFrom: "2023-11-05T16:56:52.372Z"
+        dateTo: "2023-11-15T16:56:52.372Z",
+        dateFormat: "YYYY-MM-DD"
+      }
+    )
 }
 
 type Query {

--- a/src/fake.ts
+++ b/src/fake.ts
@@ -12,7 +12,7 @@ export function getRandomItem<T>(array: ReadonlyArray<T>): T {
 export const stdScalarFakers = {
   Int: () => faker.number.int({ min: 0, max: 99999 }),
   Float: () => faker.number.float({ min: 0, max: 99999, precision: 0.01 }),
-  String: () => 'string',
+  String: () => faker.word.sample(),
   Boolean: () => faker.datatype.boolean(),
   ID: () => toBase64(faker.number.int({ max: 9999999999 }).toString()),
 };
@@ -84,6 +84,17 @@ function fakeFunctions(fakerInstance: typeof faker) {
         moment(fakerInstance.date.between({ from: dateFrom, to: dateTo }))
           .format(dateFormat)
           .toString(),
+    },
+    dateInRange: {
+      args: ['dateFormat', 'dateFrom', 'dateTo'],
+      func: (dateFormat, dateFrom, dateTo) =>
+        Array.from({
+          length: moment(dateTo).diff(moment(dateFrom), 'days'),
+        }).map((_, index) =>
+          moment(dateFrom).add(index, 'days')
+            .format(dateFormat)
+            .toString(),
+        ),
     },
     pastDate: {
       args: ['dateFormat'],

--- a/src/fake_definition.ts
+++ b/src/fake_definition.ts
@@ -65,6 +65,8 @@ const fakeDefinitionAST = parse(/* GraphQL */ `
     futureDate
     "Configure date format with option \`dateFormat\`"
     recentDate
+    "Configure date format with option \`dateFormat\`"
+    dateInRange
 
     financeAccountName
     financeTransactionType
@@ -164,6 +166,8 @@ const fakeDefinitionAST = parse(/* GraphQL */ `
     dateFrom: String = "2010-01-01"
     "Only for types \`betweenDate\`. Example value: \`2038-01-19\`."
     dateTo: String = "2030-01-01"
+    "Only for types \`betweenDate\`. Example value: \`2038-01-19\`."
+    dateInRange: [String!]
     "Only for type \`colorHex\`. [Details here](https://stackoverflow.com/a/43235/4989887)"
     baseColor: fake__color = { red255: 0, green255: 0, blue255: 0 }
     "Only for type \`number\`"

--- a/src/fake_schema.ts
+++ b/src/fake_schema.ts
@@ -102,6 +102,10 @@ export const fakeFieldResolver: GraphQLFieldResolver<unknown, unknown> = async (
     }
 
     if (isListType(type)) {
+      if (Array.isArray(fakeValueOfType(type.ofType))) {
+        return fakeValueOfType(type.ofType).sort();
+      }
+
       return Array(getListLength(fieldDef))
         .fill(null)
         .map(() => fakeValueOfType(type.ofType));


### PR DESCRIPTION
- Adds in `dateInRange` fake - this allows developer to customize the returned date.
- Updates the default value of `string` to reflect faker `word`.
- Update docker version to match package.json - error when building.

Example usage:

```
type Employee {
  id: ID
  firstName: String @fake(type: firstName, locale: en_CA)
  lastName: String @fake(type: lastName, locale: en_CA)
  address: String @fake(type: streetAddress, options: { useFullAddress: true })
  subordinates: [Employee!] @listLength(min: 0, max: 3)
  company: Company
  workDates: [String!]
    @fake(
      type: dateInRange
      options: {
        dateFrom: "2023-11-05T16:56:52.372Z"
        dateTo: "2023-11-15T16:56:52.372Z",
        dateFormat: "YYYY-MM-DD"
      }
    )
}
```

```
{
  employee(id: "test") {
    workDates
  }
}
```

```
{
  "data": {
    "employee": {
      "workDates": [
        "2023-11-05",
        "2023-11-06",
        "2023-11-07",
        "2023-11-08",
        "2023-11-09",
        "2023-11-10",
        "2023-11-11",
        "2023-11-12",
        "2023-11-13",
        "2023-11-14"
      ]
    }
  }
}
```