### PR TITLE
fix: source.unsplash.com/random was deprecated in 2024 (now 503s)

### DIFF
--- a/src/fake.ts
+++ b/src/fake.ts
@@ -120,7 +120,7 @@ function fakeFunctions(fakerInstance: typeof faker) {
     imageUrl: {
       args: ['imageSize', 'imageKeywords', 'randomizeImageUrl'],
       func: (size, keywords, randomize) => {
-        let url = 'https://source.unsplash.com/random/';
+        let url = 'https://picsum.photos/';
 
         if (size != null) {
           url += `${size.width}x${size.height}/`;


### PR DESCRIPTION
`src/fake.ts` references the deprecated `source.unsplash.com/random` endpoint, which Unsplash retired in mid-2024 and which now returns HTTP 503 instead of an image.

---

#### Why this is needed

`source.unsplash.com/random` was deprecated by Unsplash in mid-2024 and the endpoint now returns HTTP 503 instead of an image. Browsers render a broken-image icon in place of the intended visual.

Verify in any shell:

```
curl -sI https://source.unsplash.com/random/800x600?office | head -1
# HTTP/1.1 503 Service Unavailable
```

#### What this PR changes

Updates the `getRandomImage` faker source URL from the deprecated `source.unsplash.com/random/` to `picsum.photos/`, which serves a random image at the same `/<W>/<H>` path shape.

#### Replacement details

Picsum.photos is the canonical drop-in for `source.unsplash.com/random` since the deprecation; it accepts the same path shape (`/<W>/<H>`), needs no auth, and reliably returns a 200 image.

#### Background

I'm tracking the deprecated `source.unsplash.com/random` endpoint across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg isn't introduced as a dependency by this PR — the diff is dependency-free `picsum.photos`. But if you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

Research note covering ~16,500 files across ~885 unique repos that still hotlink the deprecated endpoint: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.
